### PR TITLE
Revert "msm: eva: Adding kref count for cvp_get_inst_from_id"

### DIFF
--- a/drivers/media/platform/msm/cvp/hfi_response_handler.c
+++ b/drivers/media/platform/msm/cvp/hfi_response_handler.c
@@ -426,7 +426,7 @@ retry:
 			}
 		}
 
-		inst = match && kref_get_unless_zero(&inst->kref) ? inst : NULL;
+		inst = match ? inst : NULL;
 		mutex_unlock(&core->lock);
 	} else {
 		if (core->state == CVP_CORE_UNINIT)
@@ -525,7 +525,7 @@ static int hfi_process_session_cvp_msg(u32 device_id,
 	sess_msg = kmem_cache_alloc(cvp_driver->msg_cache, GFP_KERNEL);
 	if (sess_msg == NULL) {
 		dprintk(CVP_ERR, "%s runs out msg cache memory\n", __func__);
-		goto error_no_mem;
+		return -ENOMEM;
 	}
 
 	memcpy(&sess_msg->pkt, pkt, get_msg_size());
@@ -548,14 +548,11 @@ static int hfi_process_session_cvp_msg(u32 device_id,
 
 	info->response_type = HAL_NO_RESP;
 
-	cvp_put_inst(inst);
 	return 0;
 
 error_handle_msg:
 	spin_unlock(&inst->session_queue.lock);
 	kmem_cache_free(cvp_driver->msg_cache, sess_msg);
-error_no_mem:
-	cvp_put_inst(inst);
 	return -ENOMEM;
 }
 


### PR DESCRIPTION
This reverts commit 681ecf595ad55633d95b1d9fe7fd178d06637a73.

The reverted commit is a fix for CVE-2024-38415 from November 2024 ASB, but that commit causes the camera to freeze after taking 8 or more pictures with our devices.

Change-Id: I69c09749a557ac594b9ece8002160156e84dda15