### PR TITLE
soc: qcom: smp2p_sleepstate: decrease wakeup event duration

### DIFF
--- a/drivers/soc/qcom/smp2p_sleepstate.c
+++ b/drivers/soc/qcom/smp2p_sleepstate.c
@@ -49,7 +49,7 @@ static struct notifier_block sleepstate_pm_nb = {
 
 static irqreturn_t smp2p_sleepstate_handler(int irq, void *ctxt)
 {
-	__pm_wakeup_event(notify_ws, 200);
+	__pm_wakeup_event(notify_ws, 100);
 	return IRQ_HANDLED;
 }
 


### PR DESCRIPTION
it will reduce wake-up time, in my case it's the most frequent wakelock 